### PR TITLE
Tool Bar

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,6 +13,10 @@ config_version=4
 config/name="Space Shooter Redux"
 config/icon="res://icon.png"
 
+[autoload]
+
+ToolBar="*res://sigletons/tool_bar/ToolBarSigleton.gd"
+
 [display]
 
 window/size/resizable=false

--- a/sigletons/tool_bar/ToolBarSigleton.gd
+++ b/sigletons/tool_bar/ToolBarSigleton.gd
@@ -1,0 +1,27 @@
+extends Node
+
+var _toolBarActive = true
+var _pressed = false
+
+func setToolBar(value):
+	_toolBarActive = value
+
+func getToolBarActive() -> bool:
+	return _toolBarActive
+
+func _process_tool_bar(keyCode:int):
+	if _toolBarActive:
+		match keyCode:
+			KEY_F11:
+				OS.window_fullscreen = !OS.window_fullscreen
+			KEY_F1:
+				print("close game")
+
+func _input(event):
+	if event is InputEventKey:
+		if event.pressed and !_pressed:
+			_pressed = true
+			_process_tool_bar(event.scancode)
+		elif !event.pressed:
+			!event.pressed
+			_pressed = false

--- a/tests/scripts/test_window.gd
+++ b/tests/scripts/test_window.gd
@@ -3,6 +3,7 @@ extends Node2D
 onready var player = $PlayerShip1Orange
 
 func _input(event):
+	return
 	if event is InputEventKey:
 		if event.scancode == KEY_ESCAPE and event.pressed:
 			OS.window_maximized = false


### PR DESCRIPTION
# Tool Bar
A barra de ferramentas está substiuindo os botões padrão de fechar a janela e tela cheia, por questões de resolução.
- F10 - Tela cheia
- F1 - Fechar jogo
## Observações
- O jogo não fecha ao presionar F1, por que sera solicitado a confirmação do jogador com uma modal.
<b>Em progresso</b>