### PR TITLE
Spawner positions

### DIFF
--- a/libs/regular_math.lib.gd
+++ b/libs/regular_math.lib.gd
@@ -12,6 +12,7 @@ class RectsMap:
 		var sizeY:int
 		var cellSize:int
 		var origin:Vector2
+		var offset:Vector2
 		
 		func _init(config:Dictionary):
 			_config = config
@@ -19,11 +20,18 @@ class RectsMap:
 			_generateMap()
 		
 		func _draw():
+			z_index = 100
 			if _debug:
 				var cells = getRectsAnvaliables()
 				for cell in cells:
 					draw_rect(cell, Color.red, false)
+					draw_line(cell.get_center(), cell.get_center() - Vector2(0, cell.size.y/2), Color.black)
+					draw_line(cell.get_center(), cell.get_center() - Vector2(cell.size.x/2, 0), Color.black)
+					draw_line(cell.get_center(), cell.position, Color.gray)
 					draw_circle(cell.get_center(), 2.5, Color.white)
+				draw_circle(origin, 3.5, Color.green)
+				if offset != Vector2.ZERO:
+					draw_circle(origin + offset, 3.5, Color.blue)
 		
 		func _setConfig():
 			var _size = _config.get("size", [])
@@ -32,12 +40,14 @@ class RectsMap:
 				sizeY = _size["y"]
 			cellSize = _config.get("cellSize", 0)
 			origin = _config.get("origin", Vector2.ZERO)
+			offset = _config.get("offset", Vector2.ZERO)
 			debugActive(_config.get("debug", false))
 		
 		func _generateMap():
 			for x in range(sizeX):
 				for y in range(sizeY):
 					var rect = Rect2((x * cellSize) + origin.x, (y * cellSize) + origin.y, cellSize, cellSize)
+					rect.position += offset
 					_map[toPositionWolrd2PositionMap(rect.position)] = rect
 		
 		func toPositionWolrd2PositionMap(position:Vector2, cellFit:bool = true):

--- a/members/functions/game_rules/json/functions_data/funcdata_const.functiondata
+++ b/members/functions/game_rules/json/functions_data/funcdata_const.functiondata
@@ -1,5 +1,5 @@
 {
-    "deley": [2, 6],
-    "offset": [1, 3],
+    "deley": [10],
+    "offset": [1],
     "limit": 10
 }

--- a/members/spawner/componets/spaw_functions.gd
+++ b/members/spawner/componets/spaw_functions.gd
@@ -13,6 +13,7 @@ func _on_func_const_step(value, function, metadado):
 		_newValue = dynamicResources.createNewRand(_valueMin + value, _valueMax + value)
 	else:
 		_newValue = dynamicResources.createNewRand(_valueMin + value)
+	print(spawnConfig.getConfig().getValue("countToSpaw"))
 	spawnConfig.getConfig().setValue("countToSpaw", _newValue)
 
 

--- a/members/spawner/componets/spaw_runner.gd
+++ b/members/spawner/componets/spaw_runner.gd
@@ -24,6 +24,7 @@ func run():
 			"y": mapData["y"]
 		},
 		"origin": spawConfig.positionSpaw.global_position,
+		"offset": mapData["offset"],
 		"cellSize": mapData["cell_size"],
 		"debug": true
 	})

--- a/members/spawner/componets/spaw_runner.gd
+++ b/members/spawner/componets/spaw_runner.gd
@@ -3,6 +3,7 @@ extends Componet
 signal spaw(entity)
 
 const dynamicResource = preload("res://libs/resource_dynamic.lib.gd")
+const RegularMath = preload("res://libs/regular_math.lib.gd")
 
 onready var spawnerTimer = $spawnerTimer
 onready var spawConfig = $"../.."
@@ -12,7 +13,27 @@ onready var object_pooling = $"../../object_pooling"
 var lastTimer:float
 var lastPositionSpaw:Vector2
 
+var mapSpaw
+var controllerMap
+
 func run():
+	var mapData = spawConfig.getConfig().getValue("mapData")
+	mapSpaw = RegularMath.RectsMap.Map.new({
+		"size": {
+			"x": mapData["x"],
+			"y": mapData["y"]
+		},
+		"origin": spawConfig.positionSpaw.global_position,
+		"cellSize": mapData["cell_size"],
+		"debug": true
+	})
+	var root = currentManager.get_parent()
+	root.add_child(mapSpaw)
+	
+	var algorithm = RandomNumberGenerator.new()
+	algorithm.randomize()
+	
+	controllerMap = RegularMath.RectsMap.new(mapSpaw, algorithm)
 	randomize()
 	_setTimer()
 	if spawConfig.getConfig().getValue("useFunction"):
@@ -43,8 +64,15 @@ func _preCalc():
 	else:
 		count = dynamicResource.getValueFromRand(spawConfig.getConfig().getValue("countToSpaw"), dynamicResource.Value.DEFAULT)
 	
-	for index in range(count):
-		_spaw()
+	var positions = controllerMap.getPositionsByCount(count)
+	
+	for positionMap in positions:
+		var rect = mapSpaw.getRectByPosition(positionMap)
+		var entities = object_pooling.spaw({ "group": "entities" }, {
+			"position": rect.get_center()
+		})
+
+		emit_signal("spaw", entities)
 	
 	_setTimer()
 
@@ -84,12 +112,6 @@ func _spaw():
 			position.x = pos.x
 		if position.y != 0:
 			position.y = pos.y
-	
-	var entities = object_pooling.spaw({ "group": "entities" }, {
-		"position": position + currentManager.get_parent().positionSpaw.global_position
-	})
-	
-	emit_signal("spaw", entities)
 
 func stop():
 	lastTimer = spawnerTimer.time_left

--- a/members/spawner/meta/bin/spawData.gd
+++ b/members/spawner/meta/bin/spawData.gd
@@ -9,14 +9,10 @@ enum Functions {
 export(PoolIntArray) var timeSpaw
 export(PoolIntArray) var countToSpaw
 
-export(Dictionary) var entityPosition = {
-	"x": [],
-	"y": []
-}
-
-export(Dictionary) var spawValues = {
-	"tolerance": -1,
-	"offset": -1
+export(Dictionary) var mapData = {
+	"x": 1,
+	"y": 1,
+	"cell_size": 0
 }
 
 export(bool) var useFunction

--- a/members/spawner/meta/bin/spawData.gd
+++ b/members/spawner/meta/bin/spawData.gd
@@ -12,7 +12,8 @@ export(PoolIntArray) var countToSpaw
 export(Dictionary) var mapData = {
 	"x": 1,
 	"y": 1,
-	"cell_size": 0
+	"cell_size": 0,
+	"offset": Vector2.ZERO
 }
 
 export(bool) var useFunction

--- a/members/spawner/meta/data/meteors.tres
+++ b/members/spawner/meta/data/meteors.tres
@@ -4,15 +4,12 @@
 
 [resource]
 script = ExtResource( 1 )
-timeSpaw = PoolIntArray( 8 )
-countToSpaw = PoolIntArray( 8, 12 )
-entityPosition = {
-"x": [ 0, 3350 ],
-"y": [ 0 ]
-}
-spawValues = {
-"offset": -1,
-"tolerance": -1
+timeSpaw = PoolIntArray( 5 )
+countToSpaw = PoolIntArray( 2, 3 )
+mapData = {
+"cell_size": 150,
+"x": 9,
+"y": 1
 }
 useFunction = true
 typeFunction = 0

--- a/members/spawner/meta/data/meteors.tres
+++ b/members/spawner/meta/data/meteors.tres
@@ -7,7 +7,8 @@ script = ExtResource( 1 )
 timeSpaw = PoolIntArray( 5 )
 countToSpaw = PoolIntArray( 2, 3 )
 mapData = {
-"cell_size": 150,
+"cell_size": 130,
+"offset": Vector2( -1225, -65 ),
 "x": 9,
 "y": 1
 }

--- a/members/spawner/meta/data/meteors_flames.tres
+++ b/members/spawner/meta/data/meteors_flames.tres
@@ -6,13 +6,10 @@
 script = ExtResource( 1 )
 timeSpaw = PoolIntArray( 2, 3 )
 countToSpaw = PoolIntArray( 1, 2 )
-entityPosition = {
-"x": [ 0, 3000 ],
-"y": [ 0 ]
-}
-spawValues = {
-"offset": -1,
-"tolerance": -1
+mapData = {
+"cell_size": 0,
+"x": 1,
+"y": 1
 }
 useFunction = true
 typeFunction = 1

--- a/members/spawner/script/spawner.gd
+++ b/members/spawner/script/spawner.gd
@@ -13,8 +13,6 @@ export(Dictionary) var configPooling = {
 	}
 }
 export(NodePath) var positionSpawPath
-export(int) var tolerance
-export(int) var offset
 export(bool) var initActive = true
 
 var positionSpaw:Position2D
@@ -38,18 +36,8 @@ func _configSpaw():
 	if _spawData.getValue("useFunction"):
 		controllerFunctions.configFunctions()
 		controllerFunctions.setFunctionData(_spawData.callMethod("getFunctionAsString", [_spawData.getValue("typeFunction")]), _spawData.getValue("functionData"))
-	_setSpawValue(_spawData.getValue("spawValues"))
 	if initActive:
 		spawRunner.run()
-
-func _setSpawValue(data:Dictionary):
-	var _tolerance = data["tolerance"]
-	var _offset = data["offset"]
-	if _tolerance != -1:
-		tolerance = _tolerance
-	
-	if _offset != -1:
-		offset = _offset
 
 func init():
 	spawRunner.run()

--- a/tests/game/scenes/spawner/test_spawner.tscn
+++ b/tests/game/scenes/spawner/test_spawner.tscn
@@ -19,7 +19,7 @@ positionSpawPath = NodePath("Position2D")
 initActive = false
 
 [node name="Position2D" type="Position2D" parent="spawner"]
-position = Vector2( 0, 254 )
+position = Vector2( 1280, 65 )
 
 [editable path="spawner"]
 [editable path="spawner/controller_functions"]

--- a/tests/game/scenes/spawner/test_spawner.tscn
+++ b/tests/game/scenes/spawner/test_spawner.tscn
@@ -18,10 +18,8 @@ configPooling = {
 positionSpawPath = NodePath("Position2D")
 initActive = false
 
-[node name="func_variation" parent="spawner/controller_functions/functions" index="1"]
-isLoop = true
-
 [node name="Position2D" type="Position2D" parent="spawner"]
+position = Vector2( 0, 254 )
 
 [editable path="spawner"]
 [editable path="spawner/controller_functions"]

--- a/tests/game/scenes/test_map_positions.tscn
+++ b/tests/game/scenes/test_map_positions.tscn
@@ -3,4 +3,16 @@
 [ext_resource path="res://tests/game/scripts/test_map_positions.gd" type="Script" id=1]
 
 [node name="test_no_rects_intersects" type="Node2D"]
+position = Vector2( 2560, 0 )
 script = ExtResource( 1 )
+
+[node name="content" type="Node" parent="."]
+
+[node name="Camera2D" type="Camera2D" parent="content"]
+anchor_mode = 0
+current = true
+limit_left = 0
+limit_top = 0
+limit_right = 2560
+limit_bottom = 3000
+editor_draw_limits = true

--- a/tests/game/scripts/test_map_positions.gd
+++ b/tests/game/scripts/test_map_positions.gd
@@ -9,17 +9,22 @@ const textures = [
 	preload("res://assets/sprites/enemies/enemyBlue4.png")
 	]
 
+onready var camera_2d = $content/Camera2D
+
+var velocityCamera:Vector2
+
 func _ready():
 	var map = RegularMath.RectsMap.Map.new({
 		"size": {
-			"x": 10,
+			"x": 21,
 			"y": 1
 		},
-		"cellSize": 125,
-		"origin": Vector2(10.24, 0),
+		"cellSize": 120,
+		"origin": global_position,
+		"offset": Vector2(-2520-20, 0),
 		"debug": true
 	})
-	add_child(map)
+	get_node("content").add_child(map)
 
 	var algorithm = RandomNumberGenerator.new()
 	algorithm.randomize()
@@ -31,4 +36,14 @@ func _ready():
 		sprite.texture = texture
 		var r = map.getRectByPosition(pos)
 		sprite.global_position = r.get_center()
-		add_child(sprite)
+		get_node("content").add_child(sprite)
+
+func _process(delta):
+	if Input.is_action_pressed("player_right"):
+		velocityCamera = Vector2.RIGHT
+	elif Input.is_action_pressed("player_left"):
+		velocityCamera = Vector2.LEFT
+	else:
+		velocityCamera = Vector2.ZERO
+
+	camera_2d.translate(velocityCamera * 350 * delta)


### PR DESCRIPTION
# Spawner Positions
Os spawners agora usão um mapa (grid) como referencia para gerar entidades, gerar entidades sobre esse grid, impede que as entidades gerem na mesma posição. Foi usado a classe RectsMap da blibioteca Regular Math, para gerar o mapa e calcular as posições.